### PR TITLE
Add PORT to config file and document it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 *.pyc
 .cache/
+config/dev.ini

--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ To run unit tests:
 or
 
     python -m pytest
+
+## Configuration
+
+The file config/dev.ini can contain a config file that will be
+read during testing.  If `FLASK_ENV` is set to something other
+than "dev", the `$FLASK_ENV.ini` will be used.  Here is a sample
+config file:
+
+    [default]
+    DEBUG=true
+    AUTORELOAD=true
+    REDIS_URL=redis://localhost:6379
+    PORT=8889

--- a/app.py
+++ b/app.py
@@ -4,8 +4,9 @@ import tornado.ioloop
 
 from requests_queue.make_app import make_app, make_config
 
-app = make_app(make_config())
-port = 8888
+config = make_config()
+app = make_app(config)
+port = int( config['default'].get('PORT',8888) )
 app.listen(port)
 print("Listening on http://localhost:%i" % port)
 tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
This allows the port to be specified in the config file (and documents the location of the dev config file).