### PR TITLE
create default database for user

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The app assumes that you have a local postgres 9.4+ instance running on the defa
 
 ```
 createuser -s atat
+createdb atat
 psql -c 'create database requests_queue;' -U atat
 pipenv run alembic upgrade head
 ```


### PR DESCRIPTION
My version of postgres (10) expects a default database [named after each user](https://stackoverflow.com/questions/17633422/psql-fatal-database-user-does-not-exist). I added a line to the readme. Idk, seems dumb, but whatever postgres.