### PR TITLE
Add API endpoint for submitting requests

### DIFF
--- a/api.md
+++ b/api.md
@@ -28,6 +28,8 @@ A `202 Accepted` response with no body.
 
 Update an existing request.
 
+Request:
+
 ```json
 PATCH /api/v1/requests/<request_id>
 
@@ -37,6 +39,20 @@ PATCH /api/v1/requests/<request_id>
 
     }
 }
+```
+
+Response:
+
+A `202 Accepted` response with no body.
+
+### Submit request
+
+Submit a request.
+
+Request:
+
+```json
+POST /api/v1/requests/<request_id>/submit
 ```
 
 Response:

--- a/requests_queue/handlers/requests.py
+++ b/requests_queue/handlers/requests.py
@@ -1,12 +1,13 @@
 from json import loads
 import tornado.gen
 from tornado.ioloop import IOLoop
+from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.orm.attributes import flag_modified
+from sqlalchemy import exists, and_
 
 from requests_queue.handlers.base import BaseHandler
 from requests_queue.models import Request, StatusEvent
 from requests_queue.serializers.request import RequestSerializer
-from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.orm.attributes import flag_modified
 
 
 def should_allow_submission(request):
@@ -18,7 +19,19 @@ def should_allow_submission(request):
 
 
 @tornado.gen.coroutine
-def update_request(db_session, request, request_delta):
+def update_request(db_session, request_id, request_delta):
+    try:
+        # Query for request matching id, acquiring a row-level write lock.
+        # https://www.postgresql.org/docs/10/static/sql-select.html#SQL-FOR-UPDATE-SHARE
+        request = (
+            db_session.query(Request)
+            .filter_by(id=request_id)
+            .with_for_update(of=Request)
+            .one()
+        )
+    except NoResultFound:
+        return
+
     request.body = deep_merge(request_delta, request.body)
 
     if should_allow_submission(request):
@@ -30,8 +43,6 @@ def update_request(db_session, request, request_delta):
 
     db_session.add(request)
     db_session.commit()
-
-    return None
 
 
 def parse_body(request):
@@ -56,6 +67,12 @@ def deep_merge(source, destination: dict):
     return _deep_merge(source, dict(destination))
 
 
+def request_exists(db_session, request_id, creator_id):
+    return db_session.query(
+        exists().where(and_(Request.id == request_id, Request.creator == creator_id))
+    ).scalar()
+
+
 class RequestsHandler(BaseHandler):
     def initialize(self, db_session):
         self.db_session = db_session
@@ -65,21 +82,13 @@ class RequestsHandler(BaseHandler):
         Given a request_id and a request body, recursively merge the
         request body into the existing request's body.
         """
+
         json = parse_body(self.request)
-        try:
-            # Query for request matching id, acquiring a row-level write lock.
-            # https://www.postgresql.org/docs/10/static/sql-select.html#SQL-FOR-UPDATE-SHARE
-            request = (
-                self.db_session.query(Request)
-                .filter_by(id=request_id, creator=json["creator_id"])
-                .with_for_update(of=Request)
-                .one()
-            )
-        except NoResultFound:
+        if not request_exists(self.db_session, request_id, json["creator_id"]):
             return self.send_error(404)
 
         IOLoop.current().spawn_callback(
-            update_request, self.db_session, request, json["request"]
+            update_request, self.db_session, request_id, json["request"]
         )
 
         self.set_status(202)

--- a/requests_queue/handlers/requests.py
+++ b/requests_queue/handlers/requests.py
@@ -1,20 +1,48 @@
 from json import loads
-from requests_queue.handlers.base import BaseHandler
+import tornado.gen
+from tornado.ioloop import IOLoop
 
+from requests_queue.handlers.base import BaseHandler
 from requests_queue.models import Request, StatusEvent
 from requests_queue.serializers.request import RequestSerializer
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.attributes import flag_modified
 
 
+def should_allow_submission(request):
+    all_request_sections = ["details_of_use", "information_about_you", "primary_poc"]
+    existing_request_sections = request.body.keys()
+    return request.status == "incomplete" and all(
+        section in existing_request_sections for section in all_request_sections
+    )
+
+
+@tornado.gen.coroutine
+def update_request(db_session, request, request_delta):
+    request.body = deep_merge(request_delta, request.body)
+
+    if should_allow_submission(request):
+        request.status_events.append(StatusEvent(new_status="pending_submission"))
+
+    # Without this, sqlalchemy won't notice the change to request.body,
+    # since it doesn't track dictionary mutations by default.
+    flag_modified(request, "body")
+
+    db_session.add(request)
+    db_session.commit()
+
+    return None
+
+
 def parse_body(request):
-    return loads(request.body.decode('utf-8'))
+    return loads(request.body.decode("utf-8"))
 
 
 def deep_merge(source, destination: dict):
     """
     Merge source dict into destination dict recursively.
     """
+
     def _deep_merge(a, b):
         for key, value in a.items():
             if isinstance(value, dict):
@@ -24,11 +52,11 @@ def deep_merge(source, destination: dict):
                 b[key] = value
 
         return b
+
     return _deep_merge(source, dict(destination))
 
 
 class RequestsHandler(BaseHandler):
-
     def initialize(self, db_session):
         self.db_session = db_session
 
@@ -41,29 +69,26 @@ class RequestsHandler(BaseHandler):
         try:
             # Query for request matching id, acquiring a row-level write lock.
             # https://www.postgresql.org/docs/10/static/sql-select.html#SQL-FOR-UPDATE-SHARE
-            request = (self.db_session.query(Request)
-                                      .filter_by(id=request_id, creator=json['creator_id'])
-                                      .with_for_update(of=Request)
-                                      .one())
+            request = (
+                self.db_session.query(Request)
+                .filter_by(id=request_id, creator=json["creator_id"])
+                .with_for_update(of=Request)
+                .one()
+            )
         except NoResultFound:
             return self.send_error(404)
 
-        request.body = deep_merge(json['request'], request.body)
-
-        # Without this, sqlalchemy won't notice the change to request.body,
-        # since it doesn't track dictionary mutations by default.
-        flag_modified(request, 'body')
-
-        self.db_session.commit()
+        IOLoop.current().spawn_callback(
+            update_request, self.db_session, request, json["request"]
+        )
 
         self.set_status(202)
-
 
     def post(self):
         json = parse_body(self.request)
 
-        request = Request(creator=json['creator_id'], body=json['request'])
-        status_event = StatusEvent(new_status='pending')
+        request = Request(creator=json["creator_id"], body=json["request"])
+        status_event = StatusEvent(new_status="incomplete")
         request.status_events.append(status_event)
         self.db_session.add(request)
         self.db_session.commit()

--- a/requests_queue/handlers/requests_submit.py
+++ b/requests_queue/handlers/requests_submit.py
@@ -37,7 +37,6 @@ class RequestsSubmitHandler(BaseHandler):
             request = (
                 self.db_session.query(Request)
                 .filter_by(id=request_id)
-                .with_for_update(of=Request)
                 .one()
             )
         except NoResultFound:

--- a/requests_queue/handlers/requests_submit.py
+++ b/requests_queue/handlers/requests_submit.py
@@ -18,8 +18,9 @@ def should_auto_approve(request):
 def handle_request_submitted(db_session, request):
     if should_auto_approve(request):
         request.status_events.append(StatusEvent(new_status="approved"))
-        db_session.add(request)
-        db_session.commit()
+
+    db_session.add(request)
+    db_session.commit()
 
 
 class RequestsSubmitHandler(BaseHandler):

--- a/requests_queue/handlers/requests_submit.py
+++ b/requests_queue/handlers/requests_submit.py
@@ -1,0 +1,49 @@
+import tornado.gen
+from tornado.ioloop import IOLoop
+
+from requests_queue.handlers.base import BaseHandler
+from requests_queue.models import Request, StatusEvent
+from sqlalchemy.orm.exc import NoResultFound
+
+
+def should_auto_approve(request):
+    all_request_sections = ["details_of_use", "information_about_you", "primary_poc"]
+    existing_request_sections = request.body.keys()
+    return request.status == "submitted" and all(
+        section in existing_request_sections for section in all_request_sections
+    )
+
+
+@tornado.gen.coroutine
+def handle_request_submitted(db_session, request):
+    if should_auto_approve(request):
+        request.status_events.append(StatusEvent(new_status="approved"))
+        db_session.add(request)
+        db_session.commit()
+
+
+class RequestsSubmitHandler(BaseHandler):
+    def initialize(self, db_session):
+        self.db_session = db_session
+
+    def post(self, request_id):
+        """
+        Submit a request.
+        """
+        try:
+            request = (
+                self.db_session.query(Request)
+                .filter_by(id=request_id)
+                .with_for_update(of=Request)
+                .one()
+            )
+        except NoResultFound:
+            return self.send_error(404)
+
+        request.status_events.append(StatusEvent(new_status="submitted"))
+
+        IOLoop.current().spawn_callback(
+            handle_request_submitted, self.db_session, request
+        )
+
+        self.set_status(202)

--- a/requests_queue/handlers/requests_submit.py
+++ b/requests_queue/handlers/requests_submit.py
@@ -15,7 +15,9 @@ def should_auto_approve(request):
 
 
 @tornado.gen.coroutine
-def handle_request_submitted(db_session, request):
+def submit_request(db_session, request):
+    request.status_events.append(StatusEvent(new_status="submitted"))
+
     if should_auto_approve(request):
         request.status_events.append(StatusEvent(new_status="approved"))
 
@@ -41,10 +43,8 @@ class RequestsSubmitHandler(BaseHandler):
         except NoResultFound:
             return self.send_error(404)
 
-        request.status_events.append(StatusEvent(new_status="submitted"))
-
         IOLoop.current().spawn_callback(
-            handle_request_submitted, self.db_session, request
+            submit_request, self.db_session, request
         )
 
         self.set_status(202)

--- a/requests_queue/handlers/user_requests.py
+++ b/requests_queue/handlers/user_requests.py
@@ -20,6 +20,7 @@ class UserRequestsHandler(BaseHandler):
         else:
             requests = (self.db_session.query(Request)
                                        .filter(Request.creator == user_id)
+                                       .order_by(Request.time_created.desc())
                                        .all())
             serialized_requests = RequestSerializer().dump(requests, many=True).data
             self.write({'requests': serialized_requests})

--- a/requests_queue/make_app.py
+++ b/requests_queue/make_app.py
@@ -8,6 +8,7 @@ from requests_queue.handlers.root import RootHandler
 from requests_queue.handlers.status import StatusHandler
 from requests_queue.handlers.requests import RequestsHandler
 from requests_queue.handlers.user_requests import UserRequestsHandler
+from requests_queue.handlers.requests_submit import RequestsSubmitHandler
 
 
 def make_app(config, deps):
@@ -19,6 +20,7 @@ def make_app(config, deps):
             url(r'/status', StatusHandler),
 
             url(prefix + r'/requests', RequestsHandler, {'db_session': db_session}),
+            url(prefix + r'/requests/(.*)/submit', RequestsSubmitHandler, {'db_session': db_session}),
             url(prefix + r'/requests/(.*)', RequestsHandler, {'db_session': db_session}),
 
             url(prefix + r'/users/(.*)/requests', UserRequestsHandler, {'db_session': db_session}),

--- a/tests/api/v1/test_requests.py
+++ b/tests/api/v1/test_requests.py
@@ -1,71 +1,41 @@
 import pytest
 from json import dumps, loads
-import pendulum
-
 
 sample_request_body = {
-    'details_of_use': {
-        'application_details': {
-            'application_name': 'Death Star VM',
-            'application_description': 'A moon-sized space station with abilities to destroy stuff.',
-            'estimated_use_dollars': 100000000,
-            'estimation_method': 'csp_usage_calculator',
-            'expected_start_date': pendulum.datetime(2018, 10, 1, 0, 0, 0).isoformat(),
-            'expected_usage_months': 6,
-            'classification_level': 'unclassified',
-            'service_branch': ['air_force', 'marines']
-        },
-        'computation': {
-            'num_vcpu_cores': 200,
-            'total_ram': 30000000000000,
-        },
-        'storage': {
-            'object_storage': 4000000000,
-            'server_storage': 8000000000
-        },
-        'estimated_application_usage': {
-            'active_users': 240000,
-            'peak_concurrent_users': 100000,
-            'requests_per_min_user': 100000000,
-            'environments': 4,
-        },
+    "details_of_use": {
+        "pe_id": "123",
+        "uii_ids": "1\r\n2\r\n3",
+        "total_ram": 2,
+        "date_start": "2018-07-02",
+        "total_cores": 1,
+        "dollar_value": 100,
+        "app_description": "Hello",
+        "num_applications": 1,
+        "has_migration_office": "yes",
+        "total_object_storage": 3,
+        "total_server_storage": 5,
+        "has_contractor_advisor": "yes",
+        "total_database_storage": 4,
+        "supported_organizations": "army",
+        "supporting_organization": "AF CCE/HNI",
+        "is_migrating_application": "yes",
     },
-    'professional_services': {
-        'have_migration_contractor': True,
-        'have_cloud_contractor': True,
-        'need_cloud_contractor': False,
-        'will_be_developed_by_contractor': True,
-        'needs_native_cloud_infrastructure': True,
+    "information_about_you": {
+        "citizenship": "United States",
+        "designation": "hello",
+        "phone_number": "7728349265",
+        "email_request": "meow@hello.com",
+        "fname_request": "Richard",
+        "lname_request": "Howard",
+        "service_branch": "army",
+        "date_latest_training": "2018-06-24",
     },
-    'organization': {
-        'user': {
-            'name': 'Friedrich Straat',
-            'email': 'fstraat@dds.mil',
-            'phone': '1234567890',
-            'location': 'Ft. Gordon',
-            'organization': 'DDS',
-            'office_symbol': 'Department of Defense',
-            'citizenship': 'foreign_national',
-            'designation': 'military',
-            'latest_ia_completion_date': '',
-            'collaborators': [
-                {
-                    'name': 'Pietro Quirinis',
-                    'email': 'quirinis@gov.mil',
-                    'role': 'contracting_officer'
-                },
-                {
-                    'name': '',
-                    'email': '',
-                    'role': 'financial_manager'
-                }
-            ]
-        }
+    "primary_poc": {
+        "dodid_poc": "1234567890",
+        "email_poc": "richard@promptworks.com",
+        "fname_poc": "a",
+        "lname_poc": "b",
     },
-    'task_order': {
-        'order_number': '1234',
-        'funding_type': 'rdte'
-    }
 }
 
 sample_post_body = {
@@ -179,3 +149,27 @@ def test_request_starts_out_pending(http_client, base_url):
         method='GET')
     assert response.code == 200
     assert loads(response.body)['status'] == 'pending'
+
+
+@pytest.mark.gen_test
+def test_submit_triggers_auto_approval(http_client, base_url):
+    response = yield http_client.fetch(
+        base_url + '/api/v1/requests',
+        method='POST',
+        headers={'Content-Type': 'application/json'},
+        body=dumps(sample_post_body))
+    request_id = loads(response.body)['id']
+
+    yield http_client.fetch(
+        base_url + '/api/v1/requests/{}/submit'.format(request_id),
+        method='POST',
+        body=dumps({}),
+        headers={'Content-Type': 'application/json'}
+    )
+
+    response = yield http_client.fetch(
+        '{}/api/v1/users/{}/requests/{}'.format(
+            base_url, sample_post_body['creator_id'], request_id),
+        method='GET')
+    assert response.code == 200
+    assert loads(response.body)['status'] == 'approved'

--- a/tests/api/v1/test_requests.py
+++ b/tests/api/v1/test_requests.py
@@ -38,9 +38,35 @@ sample_request_body = {
     },
 }
 
+partial_request_body = {
+    "details_of_use": {
+        "pe_id": "123",
+        "uii_ids": "1\r\n2\r\n3",
+        "total_ram": 2,
+        "date_start": "2018-07-02",
+        "total_cores": 1,
+        "dollar_value": 100,
+        "app_description": "Hello",
+        "num_applications": 1,
+        "has_migration_office": "yes",
+        "total_object_storage": 3,
+        "total_server_storage": 5,
+        "has_contractor_advisor": "yes",
+        "total_database_storage": 4,
+        "supported_organizations": "army",
+        "supporting_organization": "AF CCE/HNI",
+        "is_migrating_application": "yes",
+    },
+}
+
 sample_post_body = {
     'creator_id': 'e59a9d20-c31e-47f5-a9ae-d791ad8fffa4',
     'request': sample_request_body,
+}
+
+partial_post_body = {
+    'creator_id': 'e59a9d20-c31e-47f5-a9ae-d791ad8fffa4',
+    'request': partial_request_body,
 }
 
 
@@ -92,6 +118,21 @@ def test_update_request(http_client, base_url):
     )
     assert response.code == 202
 
+    response = yield http_client.fetch(
+        base_url + '/api/v1/users/{}/requests/{}'.format(creator_id, request_id),
+        method='GET',
+        headers={'Content-Type': 'application/json'}
+    )
+    assert loads(response.body)['body'] == {
+        'red': {
+            'a': 1,
+            'b': 20,
+            'c': 3
+        },
+        'green': [1, 2, 3],
+        'blue': 3
+    }
+
 @pytest.mark.gen_test
 def test_update_nonexistent_request(http_client, base_url):
     response = yield http_client.fetch(
@@ -135,12 +176,12 @@ def test_get_user_request(http_client, base_url):
     assert loads(response.body)['id'] == request_id
 
 @pytest.mark.gen_test
-def test_request_starts_out_pending(http_client, base_url):
+def test_request_starts_out_incomplete(http_client, base_url):
     response = yield http_client.fetch(
         base_url + '/api/v1/requests',
         method='POST',
         headers={'Content-Type': 'application/json'},
-        body=dumps(sample_post_body))
+        body=dumps(partial_post_body))
     request_id = loads(response.body)['id']
 
     response = yield http_client.fetch(
@@ -148,7 +189,30 @@ def test_request_starts_out_pending(http_client, base_url):
             base_url, sample_post_body['creator_id'], request_id),
         method='GET')
     assert response.code == 200
-    assert loads(response.body)['status'] == 'pending'
+    assert loads(response.body)['status'] == 'incomplete'
+
+@pytest.mark.gen_test
+def test_finishing_request_moves_it_to_pending_submission(http_client, base_url):
+    creator_id = '9dcbb00f-e171-41c8-80e9-40ada34a4bc8'
+    response = yield http_client.fetch(
+        base_url + '/api/v1/requests',
+        method='POST',
+        headers={'Content-Type': 'application/json'},
+        body=dumps({'creator_id': creator_id, 'request': {'incomplete': 'request'}}))
+    request_id = loads(response.body)['id']
+
+
+    response = yield http_client.fetch(
+        base_url + '/api/v1/requests/{}'.format(request_id),
+        method='PATCH',
+        headers={'Content-Type': 'application/json'},
+        body=dumps({'creator_id': creator_id, 'request': sample_request_body}))
+
+    response = yield http_client.fetch(
+        '{}/api/v1/users/{}/requests/{}'.format(
+            base_url, sample_post_body['creator_id'], request_id),
+        method='GET')
+    assert loads(response.body)['status'] == 'pending_submission'
 
 
 @pytest.mark.gen_test


### PR DESCRIPTION
Allow requests to be submitted. Submission triggers an asynchronous handler that tries to approve the request automatically if it meets the requirements (stubbed out, as those requirements are to be determined).

Also, requests now start out in an `incomplete` state. Once it's fully filled out, it will move to a `pending_submission` state.