### PR TITLE
Add script for opening an ipython repl

### DIFF
--- a/ipython_setup.py
+++ b/ipython_setup.py
@@ -3,3 +3,5 @@ from requests_queue.database import make_db
 from requests_queue.models import *
 
 db = make_db(make_config())
+
+print("\nWelcome to requests-queue. This shell has all models in scope, and a SQLAlchemy session called db.")

--- a/ipython_setup.py
+++ b/ipython_setup.py
@@ -1,0 +1,5 @@
+from requests_queue.make_app import make_config
+from requests_queue.database import make_db
+from requests_queue.models import *
+
+db = make_db(make_config())

--- a/script/console
+++ b/script/console
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# If a command fails, exit the script
+set -e
+
+# Ensure we are in the app root directory (not the /script directory)
+cd "$(dirname "${0}")/.."
+
+pipenv run ipython -i ./ipython_setup.py


### PR DESCRIPTION
`script/console` opens an `ipython` repl with a database session and all models in scope.

Inspired by https://github.com/github/scripts-to-rule-them-all.