### PR TITLE
Postgres extension names require double-quotes

### DIFF
--- a/alembic/versions/26d09aea3704_enable_uuid_extension.py
+++ b/alembic/versions/26d09aea3704_enable_uuid_extension.py
@@ -23,4 +23,4 @@ def upgrade():
 
 def downgrade():
     connection = op.get_bind()
-    connection.execute("DROP EXTENSION IF EXISTS 'uuid-ossp'")
+    connection.execute('DROP EXTENSION IF EXISTS "uuid-ossp"')


### PR DESCRIPTION
I thought I'd fixed this, but there was an issue with the downgrade step of the "base" migration. I noticed it when running `alembic downgrade base`.